### PR TITLE
Fix manage files for experiments by addressing root folder consistently.

### DIFF
--- a/src/main/java/hci/gnomex/utility/FileDescriptorUploadParser.java
+++ b/src/main/java/hci/gnomex/utility/FileDescriptorUploadParser.java
@@ -1,6 +1,5 @@
 package hci.gnomex.utility;
 
-
 import hci.framework.model.DetailObject;
 import hci.gnomex.constants.Constants;
 
@@ -8,163 +7,147 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import org.jdom.Document;
-import org.jdom.Element;
 
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
-
 public class FileDescriptorUploadParser extends DetailObject implements Serializable {
-  
-  protected JsonObject files;
-  protected JsonArray  filesToRemove;
-  protected Map        fileNameMap = new LinkedHashMap();
-  protected List       newDirectoryNames = new ArrayList();
-  protected Map        filesToRename = new LinkedHashMap();
-  protected Map        foldersToRename = new LinkedHashMap();
-  
-  public FileDescriptorUploadParser(JsonObject files) {
-    this.files = files;
-  }
-  public FileDescriptorUploadParser(JsonArray filesToRemoveList){
-    this.filesToRemove = filesToRemoveList;
-  }
 
-  
-  public void parse() throws Exception{
-    fileNameMap = new LinkedHashMap();
-    newDirectoryNames = new ArrayList();
-    
-    JsonObject root = this.files;
+    protected JsonObject                    files;
+    private JsonArray                       filesToRemove;
+    private Map<String, List<String>>       fileNameMap = new LinkedHashMap<>();
+    private List<String>                    newDirectoryNames = new ArrayList<>();
+    private Map<String, String>             filesToRename = new LinkedHashMap<>();
+    private Map<String, String>             foldersToRename = new LinkedHashMap<>();
 
-
-    JsonArray requestDownloadList = root.get("RequestDownload") != null ? root.getJsonArray("RequestDownload") : Json.createArrayBuilder().build();
-    
-    for(int i = 0; i < requestDownloadList.size(); i++) {
-      JsonObject folderObj = requestDownloadList.getJsonObject(i);
-      String requestNumber = folderObj.get("requestNumber") != null ? folderObj.getString("requestNumber") : "";
-      String []keyTokens = (folderObj.get("key") != null ? folderObj.getString("key") : "").split(Constants.DOWNLOAD_KEY_SEPARATOR);
-      String directoryName = keyTokens[3];
-      String newName = folderObj.get("newName") != null ? folderObj.getString("newName") : "";
-      if(!newName.equals("")){
-        foldersToRename.put(directoryName, newName);
-      }
-
-      // Keep track of all new folders
-      recurseDirectories(folderObj, null, "RequestDownload");
+    public FileDescriptorUploadParser(JsonObject files) {
+        this.files = files;
     }
 
-    JsonArray fileDescriptorList = root.get("FileDescriptor") != null ? root.getJsonArray("FileDescriptor") : Json.createArrayBuilder().build();
-    if(fileDescriptorList.size() > 0){
-      recurseDirectories(root , null, "Request");
+    public FileDescriptorUploadParser(JsonArray filesToRemoveList) {
+        this.filesToRemove = filesToRemoveList;
     }
 
- }
-  
-  private void recurseDirectories(JsonObject folderObj, String parentDir, String objName) {
-    String directoryName = null;
-    if (objName.equals("RequestDownload")) {
-      String []keyTokens = (folderObj.get("key") != null ? folderObj.getString("key") : "" ).split(Constants.DOWNLOAD_KEY_SEPARATOR);
-      directoryName = keyTokens[3];
-      
-    } else if (folderObj.get("type") != null && folderObj.getString("type").equals("dir")) {
-      directoryName = folderObj.get("displayName") != null ? folderObj.getString("displayName") : "";
-    }
-    else if(objName.equals("Request")){
-      directoryName = folderObj.get("displayName") != null ? folderObj.getString("displayName") : "";
-      directoryName = directoryName.substring(0, directoryName.indexOf("R") + 1); //Strip any revision number off
-    }
-    
-    if (directoryName == null) {
-      return;
-    }
+    public void parse() throws Exception {
+        fileNameMap = new LinkedHashMap<>();
+        newDirectoryNames = new ArrayList<>();
 
-    String qualifiedDir = parentDir != null ? parentDir  + File.separator + directoryName : directoryName;
-    if (folderObj.get("isNew") != null && folderObj.getString("isNew").equals("Y")) {
-      newDirectoryNames.add(qualifiedDir);
-    }
-    
-    // Get the files to be moved
-    JsonArray fileDescriptorList = folderObj.get("FileDescriptor") != null ? folderObj.getJsonArray("FileDescriptor") : Json.createArrayBuilder().build();
-    for(int i = 0; i < fileDescriptorList.size(); i++) {
-      JsonObject fileObj = fileDescriptorList.getJsonObject(i);
-      //Check to see if we need to rename anything
-      String fileName = (fileObj.get("fileName") != null ? fileObj.getString("fileName") : "") .replaceAll("\\\\", Constants.FILE_SEPARATOR);
-      String displayName = fileObj.get("displayName") != null ? fileObj.getString("displayName") : "";
-      String newFileName = fileName.replace(fileName.substring(fileName.lastIndexOf(Constants.FILE_SEPARATOR) + 1), displayName);
-      if(!newFileName.equals(fileName) && !fileName.equals("")){
-        filesToRename.put(fileName, newFileName);
-      }
+        JsonObject root = this.files;
 
-      // Ignore new directories here.
-      if (fileObj.get("isNew") != null && fileObj.getString("isNew").equals("Y")) {
-        continue;
-      }
-      
-      fileName = fileObj.get("fileName") != null ? fileObj.getString("fileName") : "";
-      
-      List fileNames = (List)fileNameMap.get(qualifiedDir);
-      if (fileNames == null) {
-        fileNames = new ArrayList();
-        qualifiedDir = qualifiedDir.replace("\\", Constants.FILE_SEPARATOR);
-        fileNameMap.put(qualifiedDir, fileNames);
-      }
-      fileNames.add(fileName);
-    }
+        JsonArray requestDownloadList = root.get("RequestDownload") != null ? root.getJsonArray("RequestDownload") : Json.createArrayBuilder().build();
 
-    if(!objName.equals("Request")){
-      JsonArray requestDownloadList = folderObj.get("RequestDownload") != null ? folderObj.getJsonArray("RequestDownload") : Json.createArrayBuilder().build();
-      for(int i = 0; i < requestDownloadList.size(); i++) {
-        JsonObject childFolderObj = requestDownloadList.getJsonObject(i);
-        if(childFolderObj.get("newName") != null && !childFolderObj.getString("newName").equals("")){
-          foldersToRename.put(directoryName, childFolderObj.get("newName"));
+        for (int i = 0; i < requestDownloadList.size(); i++) {
+            JsonObject folderObj = requestDownloadList.getJsonObject(i);
+            String[] keyTokens = Util.getJsonStringSafeNonNull(folderObj, "key").split(Constants.DOWNLOAD_KEY_SEPARATOR);
+            String directoryName = keyTokens[3];
+            String newName = Util.getJsonStringSafeNonNull(folderObj, "newName");
+            if (!newName.equals("")) {
+                foldersToRename.put(directoryName, newName);
+            }
+
+            // Keep track of all new folders
+            recurseDirectories(folderObj, null, "RequestDownload");
         }
-        recurseDirectories(childFolderObj, qualifiedDir, "RequestDownload");
-      }
-    }
-    
-    for(int i = 0; i < fileDescriptorList.size(); i++) {
-      JsonObject childFolderObj = fileDescriptorList.getJsonObject(i);
-      recurseDirectories(childFolderObj, qualifiedDir, "FileDescriptor");
-    }
-    
-  }
-  
-  public List getNewDirectoryNames() {
-    return newDirectoryNames;
-  }
-  
-  public List parseFilesToRemove() throws Exception {
-    ArrayList fileNames = new ArrayList();
-    
 
-    for(int i = 0; i < this.filesToRemove.size();  i++) {
-       JsonObject fileObj = filesToRemove.getJsonObject(i);
-//      System.out.println("ready to remove  fileName" + node.getAttributeValue("fileName"));
-      fileNames.add(fileObj.get("fileName") != null ? fileObj.getString("fileName") : "");
+        JsonArray fileDescriptorList = root.get("FileDescriptor") != null ? root.getJsonArray("FileDescriptor") : Json.createArrayBuilder().build();
+        if (fileDescriptorList.size() > 0) {
+            recurseDirectories(root, null, "Request");
+        }
     }
 
-    return fileNames;
-    
-  }
-  
-  public Map getFileNameMap() {
-    return fileNameMap;
-  }
-  
-  public Map getFilesToRenameMap(){
-    return filesToRename;
-  }
-  
-  public Map getFoldersToRenameMap(){
-    return foldersToRename;
-  }
+    private void recurseDirectories(JsonObject folderObj, String parentDir, String objName) {
+        String directoryName = null;
+        if (objName.equals("RequestDownload")) {
+            String[] keyTokens = Util.getJsonStringSafeNonNull(folderObj, "key").split(Constants.DOWNLOAD_KEY_SEPARATOR);
+            directoryName = keyTokens[3];
+        } else if (Util.getJsonStringSafeNonNull(folderObj, "type").equals("dir")) {
+            directoryName = Util.getJsonStringSafeNonNull(folderObj, "displayName");
+        } else if (objName.equals("Request")) {
+            directoryName = "";
+        }
 
+        if ((directoryName == null || directoryName.equals("")) && !objName.equals("Request")) {
+            return;
+        }
+
+        String qualifiedDir = parentDir != null && !parentDir.equals("") ? parentDir + File.separator + directoryName : directoryName;
+        if (!qualifiedDir.equals("") && Util.getJsonStringSafeNonNull(folderObj, "isNew").equals("Y")) {
+            newDirectoryNames.add(qualifiedDir);
+        }
+
+        // Get the files to be moved
+        JsonArray fileDescriptorList = folderObj.get("FileDescriptor") != null ? folderObj.getJsonArray("FileDescriptor") : Json.createArrayBuilder().build();
+        for (int i = 0; i < fileDescriptorList.size(); i++) {
+            JsonObject fileObj = fileDescriptorList.getJsonObject(i);
+            //Check to see if we need to rename anything
+            String fileName = Util.getJsonStringSafeNonNull(fileObj, "fileName").replaceAll("\\\\", Constants.FILE_SEPARATOR);
+            String displayName = Util.getJsonStringSafeNonNull(fileObj, "displayName");
+            String newFileName = fileName.replace(fileName.substring(fileName.lastIndexOf(Constants.FILE_SEPARATOR) + 1), displayName);
+            if (!newFileName.equals(fileName) && !fileName.equals("")) {
+                filesToRename.put(fileName, newFileName);
+            }
+
+            // Ignore new directories here.
+            if (Util.getJsonStringSafeNonNull(fileObj, "isNew").equals("Y")) {
+                continue;
+            }
+
+            fileName = Util.getJsonStringSafeNonNull(fileObj, "fileName");
+
+            List<String> fileNames = fileNameMap.get(qualifiedDir);
+            if (fileNames == null) {
+                fileNames = new ArrayList<>();
+                qualifiedDir = qualifiedDir.replace("\\", Constants.FILE_SEPARATOR);
+                fileNameMap.put(qualifiedDir, fileNames);
+            }
+            fileNames.add(fileName);
+        }
+
+        if (!objName.equals("Request")) {
+            JsonArray requestDownloadList = folderObj.get("RequestDownload") != null ? folderObj.getJsonArray("RequestDownload") : Json.createArrayBuilder().build();
+            for (int i = 0; i < requestDownloadList.size(); i++) {
+                JsonObject childFolderObj = requestDownloadList.getJsonObject(i);
+                if (!Util.getJsonStringSafeNonNull(childFolderObj, "newName").equals("")) {
+                    foldersToRename.put(directoryName, Util.getJsonStringSafeNonNull(childFolderObj, "newName"));
+                }
+                recurseDirectories(childFolderObj, qualifiedDir, "RequestDownload");
+            }
+        }
+
+        for (int i = 0; i < fileDescriptorList.size(); i++) {
+            JsonObject childFolderObj = fileDescriptorList.getJsonObject(i);
+            recurseDirectories(childFolderObj, qualifiedDir, "FileDescriptor");
+        }
+    }
+
+    public List<String> getNewDirectoryNames() {
+        return newDirectoryNames;
+    }
+
+    public List<String> parseFilesToRemove() {
+        ArrayList<String> fileNames = new ArrayList<>();
+
+        for (int i = 0; i < this.filesToRemove.size(); i++) {
+            JsonObject fileObj = filesToRemove.getJsonObject(i);
+            fileNames.add(Util.getJsonStringSafeNonNull(fileObj, "fileName"));
+        }
+
+        return fileNames;
+    }
+
+    public Map<String, List<String>> getFileNameMap() {
+        return fileNameMap;
+    }
+
+    public Map<String, String> getFilesToRenameMap() {
+        return filesToRename;
+    }
+
+    public Map<String, String> getFoldersToRenameMap() {
+        return foldersToRename;
+    }
 
 }


### PR DESCRIPTION
When organizing experiment files, OrganizeExperimentUploadFiles and FileDescriptorUploadParser build the base path of files and folders differently. The controller adds the request number to its base path, which then gets duplicated when the parser also adds it as a root folder. This commit synchronizes the parser to the controller's logic.