### PR TITLE
Fix combo box showing only None when options change by calling filter…

### DIFF
--- a/gnomex_ng/src/app/util/custom-combo-box.component.ts
+++ b/gnomex_ng/src/app/util/custom-combo-box.component.ts
@@ -54,6 +54,7 @@ export class CustomComboBoxComponent implements AfterViewInit, OnChanges, OnDest
     public forceShowNone: boolean = false;
 
     @Input() private options: any[] = [];
+    public isOpen: boolean = false;
     public includeLoadingOption: boolean = true;
     public loadedOptions: any[] = [];
 
@@ -106,9 +107,17 @@ export class CustomComboBoxComponent implements AfterViewInit, OnChanges, OnDest
             if (!optionsChange.currentValue) {
                 this.options = [];
             }
+            this.includeLoadingOption = true;
         }
 
-        this.loadOnlyCurrentValue();
+        setTimeout(() => {
+            if (this.isOpen) {
+                this.filterOptions();
+                this.includeLoadingOption = false;
+            } else {
+                this.loadOnlyCurrentValue();
+            }
+        });
     }
 
     writeValue(obj: any): void {
@@ -177,6 +186,7 @@ export class CustomComboBoxComponent implements AfterViewInit, OnChanges, OnDest
     }
 
     public onOpened(): void {
+        this.isOpen = true;
         this.onTouchedFn();
         this.inputElement.nativeElement.select(); // Highlights text
 
@@ -187,6 +197,7 @@ export class CustomComboBoxComponent implements AfterViewInit, OnChanges, OnDest
     }
 
     public onClosed(): void {
+        this.isOpen = false;
         if (!this.innerControl.value && this.outerControl.value) {
             this.selectOption(null);
         }


### PR DESCRIPTION
… in ngOnChanges

The custom combo box implements a lazy-loading feature, meaning the list of options appearing in the *ngFor loop in the template for the mat-options does not match the list of options bound to the component. If the options input array changes when the mat-select is open, therefore, the new list of options will not appear unless the mat-select is first closed and re-opened. This is fixed by checking if the mat-select is open in the ngOnChanges function and re-calling the appropriate filter function.