### PR TITLE
Add split billing to new experiment order process

### DIFF
--- a/gnomex_ng/src/app/experiments/new-experiment/new-experiment-setup.component.html
+++ b/gnomex_ng/src/app/experiments/new-experiment/new-experiment-setup.component.html
@@ -60,14 +60,19 @@
             </li>
             <li *ngIf="showBilling" class="full-width align-baseline">
                 <div class="full-width flex-container-row">
-                    <div class="flex-container-row align-baseline">
-                        <div class="heading">
-                            Select a payment method :
+                    <div class="flex-container-col">
+                        <div class="flex-container-row align-baseline">
+                            <div class="heading">
+                                Select a payment method :
+                            </div>
+                            <custom-combo-box class="moderate-width" placeholder="Account" (optionSelected)="onBillingAccountSelection($event)"
+                                              displayField="accountNameDisplay" [options]="authorizedBillingAccounts"
+                                              [formControlName]="'selectAccount'">
+                            </custom-combo-box>
                         </div>
-                        <custom-combo-box class="moderate-width" placeholder="Account" (optionSelected)="onBillingSelection($event)"
-                                          displayField="accountNameDisplay" [options]="authorizedBillingAccounts"
-                                          [formControlName]="'selectAccount'">
-                        </custom-combo-box>
+                        <div class="flex-container-col" *ngIf="this.form.get('selectBillingTemplate').value">
+                            <span *ngFor="let item of this.form.get('selectBillingTemplate').value.items" class="margin-left">{{item.accountNameDisplay}}</span>
+                        </div>
                     </div>
                     <div class="flex-column-container moderate-width major-padding-left">
                         <div class="double-padded-left instructions">

--- a/gnomex_ng/src/app/experiments/new-experiment/tab-confirm-illumina.component.html
+++ b/gnomex_ng/src/app/experiments/new-experiment/tab-confirm-illumina.component.html
@@ -77,6 +77,9 @@
                             <div class="td right-align padded">
                                 {{ billingItem.unitPrice ? '' + billingItem.unitPrice : '' }}
                             </div>
+                            <div *ngIf="billingItem.percentagePrice !== '1'" class="td padded">
+                                ({{ billingItem.percentageDisplay ? '' + billingItem.percentageDisplay : '' }})
+                            </div>
                             <div class="td padded heavily-right-padded">
                                 =
                             </div>

--- a/gnomex_ng/src/app/experiments/new-experiment/tab-confirm-illumina.component.ts
+++ b/gnomex_ng/src/app/experiments/new-experiment/tab-confirm-illumina.component.ts
@@ -752,7 +752,14 @@ export class TabConfirmIlluminaComponent implements OnInit, OnDestroy {
             } else {
                 let accountName:String = "";
 
-                if (this._experiment.billingAccount != null) {
+                if (this.experiment.billingTemplate != null && this.experiment.billingTemplate.items != null) {
+                    for (let templateItem of this.experiment.billingTemplate.items) {
+                        if (accountName) {
+                            accountName += ", ";
+                        }
+                        accountName += templateItem.accountNumberDisplay;
+                    }
+                } else if (this._experiment.billingAccount != null) {
                     accountName = this._experiment.billingAccount.accountNumberDisplay;
                 } else if (this.experiment.accountNumberDisplay) {
                     accountName = this.experiment.accountNumberDisplay;


### PR DESCRIPTION
Hooked up the billing template window to the New Experiment Order screen(s) and adjusted the back-end to properly parse either case. The user can still select a single billing account like before.