### PR TITLE
Add text preview for .Rmd files for analyses

### DIFF
--- a/src/main/java/hci/gnomex/controller/DownloadAnalysisSingleFileServlet.java
+++ b/src/main/java/hci/gnomex/controller/DownloadAnalysisSingleFileServlet.java
@@ -108,7 +108,8 @@ public class DownloadAnalysisSingleFileServlet extends HttpServlet {
             secAdvisor = (SecurityAdvisor) req.getSession().getAttribute(SecurityAdvisor.SECURITY_ADVISOR_SESSION_KEY);
 
             if (secAdvisor != null) {
-                String mimeType = req.getSession().getServletContext().getMimeType(fileName);
+                String mimeSpoofName = DownloadSingleFileServlet.SpoofTxtFiles(fileName);
+                String mimeType = req.getSession().getServletContext().getMimeType(mimeSpoofName);
                 if (view.equals("Y") && mimeType != null) {
                     response.setContentType(mimeType);
                     response.setHeader("Content-Disposition", "filename=" + "\"" + fileName + "\"");

--- a/src/main/java/hci/gnomex/controller/DownloadSingleFileServlet.java
+++ b/src/main/java/hci/gnomex/controller/DownloadSingleFileServlet.java
@@ -632,7 +632,7 @@ private boolean processIMG (String imgline, OutputStream out, String dir, String
    *                    returns the properly-formatted filename with a .txt extension.
    *                    Otherwise, returns the original filename.
    */
-  private String SpoofTxtFiles(String fileName) {
+  public static String SpoofTxtFiles(String fileName) {
       String spoofName = fileName;
 
       if (fileName != null && !fileName.equals("")) {


### PR DESCRIPTION
Users can see a text preview of .Rmd files under experiments, but not
for analyses. This functionality was copied over so the preview works
consistently for analysis files as well.