### PR TITLE
Add loading spinner to refresh dictionaries

### DIFF
--- a/gnomex_ng/src/app/configuration/browse-dictionary.component.ts
+++ b/gnomex_ng/src/app/configuration/browse-dictionary.component.ts
@@ -518,8 +518,12 @@ export class BrowseDictionaryComponent extends BaseGenericContainerDialog implem
     public refreshAll(): void {
         this.selectedDictionary = null;
         this.selectedEntry = null;
+        this.dialogsService.addSpinnerWorkItem();
         this.dictionaryService.reloadAndRefresh(() => {
             this.buildTree();
+            this.dialogsService.removeSpinnerWorkItem();
+        }, () => {
+            this.dialogsService.stopAllSpinnerDialogs();
         });
     }
 


### PR DESCRIPTION
On Add / Edit Dictionaries screen, clicking the refresh button would
not provide user feedback. Now a modal loading spinner appears during
the relatively lengthy process.